### PR TITLE
Updated GUID when connecting 

### DIFF
--- a/EnableAzureArc.ps1
+++ b/EnableAzureArc.ps1
@@ -277,7 +277,7 @@ Function Connect-ArcAgent {
     if ($AgentProxy -ne "") {
         $Proxyconf = & "$env:ProgramW6432\AzureConnectedMachineAgent\azcmagent.exe" config set proxy.url $AgentProxy
     }
-    $ConnectionOuput = & "$env:ProgramW6432\AzureConnectedMachineAgent\azcmagent.exe" connect --service-principal-id $servicePrincipalClientId --service-principal-secret $sps --resource-group $ResourceGroup --tenant-id $tenantid --location $location --subscription-id $subscriptionid --cloud AzureCloud --tags $FinalTag --correlation-id $((New-Guid).guid)
+    $ConnectionOuput = & "$env:ProgramW6432\AzureConnectedMachineAgent\azcmagent.exe" connect --service-principal-id $servicePrincipalClientId --service-principal-secret $sps --resource-group $ResourceGroup --tenant-id $tenantid --location $location --subscription-id $subscriptionid --cloud AzureCloud --tags $FinalTag --correlation-id "478b97c2-9310-465a-87df-f21e66c2b248"
     
 
     if ($LastExitCode -eq 0) {


### PR DESCRIPTION
For metric purposes, it is easier if all GPO onboarded machines have the same correlation id