### PR TITLE
Copy psm1 file locally before importing

### DIFF
--- a/EnableAzureArc.ps1
+++ b/EnableAzureArc.ps1
@@ -247,11 +247,11 @@ Function Update-ArcAgent {
 }
 Function Get-ServicePrincipalSecret {
     try {
-        Copy-Item (Join-Path $SourceFilesFullPath "AzureArcDeployment.psm1") $workfolder
+        Copy-Item (Join-Path $SourceFilesFullPath "AzureArcDeployment.psm1") $workfolder -Force
         Import-Module (Join-Path $workfolder "AzureArcDeployment.psm1")
         $encryptedSecret = Get-Content (Join-Path $SourceFilesFullPath encryptedServicePrincipalSecret)
         $sps = [DpapiNgUtil]::UnprotectBase64($encryptedSecret)
-        Remove-Item (Join-Path $workfolder "AzureArcDeployment.psm1")
+        Remove-Item (Join-Path $workfolder "AzureArcDeployment.psm1") -Force
     }
     catch {
         Write-Log -msg "Could not fetch service principal secret: $($_.Exception)" -msgtype ERROR

--- a/EnableAzureArc.ps1
+++ b/EnableAzureArc.ps1
@@ -247,9 +247,11 @@ Function Update-ArcAgent {
 }
 Function Get-ServicePrincipalSecret {
     try {
-        Import-Module (Join-Path $SourceFilesFullPath "AzureArcDeployment.psm1")
+        Copy-Item (Join-Path $SourceFilesFullPath "AzureArcDeployment.psm1") $workfolder
+        Import-Module (Join-Path $workfolder "AzureArcDeployment.psm1")
         $encryptedSecret = Get-Content (Join-Path $SourceFilesFullPath encryptedServicePrincipalSecret)
         $sps = [DpapiNgUtil]::UnprotectBase64($encryptedSecret)
+        Remove-Item (Join-Path $workfolder "AzureArcDeployment.psm1")
     }
     catch {
         Write-Log -msg "Could not fetch service principal secret: $($_.Exception)" -msgtype ERROR


### PR DESCRIPTION
For some customers, when using the psm1 file, the ExecutionPolicy prevents it from being imported properly. This may be solved in some situations by copying it locally first.