### PR TITLE
Do not downgrade to the version on the network share if they don't match

### DIFF
--- a/EnableAzureArc.ps1
+++ b/EnableAzureArc.ps1
@@ -209,7 +209,7 @@ Function Update-ArcAgentVersion {
     #Compare versions
 
 
-    if ($LocalAgentVersion -ne $NetworkShareVersion) {
+    if ($LocalAgentVersion -lt $NetworkShareVersion) {
         # New Agent Version Found
         Write-Log -msg "New Agent version found in network share folder: $($NetworkShareVersion.ToString()) , local version is $($LocalAgentVersion.ToString()). Executing update ..." -msgtype WARNING
     


### PR DESCRIPTION
The script will downgrade an install of Azure Connected Machine Agent to the network share version, preventing updates from taking place.

This could re-open security vulnerabilities per bug report.

- Fixes #37 