### PR TITLE
Update DeployGPO.ps1

### DIFF
--- a/DeployGPO.ps1
+++ b/DeployGPO.ps1
@@ -64,7 +64,7 @@ Param (
 
     [System.String]$AgentProxy,
 
-    [Hashtable]$Tags,
+    [System.String]$Tags,
 
     [System.String]$PrivateLinkScopeId,
     [switch]$AssessOnly


### PR DESCRIPTION
Ran into this error and fixed it on the script. Looks like it was supposed to be a string, not a hashtable.

: Cannot process argument transformation on parameter 'Tags'. Cannot convert the "City=x,StateOrDistrict=y,CountryOrRegion=Z" value of type "System.String" to type "System.Collections.Hashtable".