### PR TITLE
Fix double dash on -ResourceGroup parameter in README.md and DeployGPO.ps1

### DIFF
--- a/DeployGPO.ps1
+++ b/DeployGPO.ps1
@@ -33,7 +33,7 @@
    to the remote share AzureArcOnBoard in the Server.contoso.com server
 
    .\DeployGPO.ps1 -DomainFQDN contoso.com -ReportServerFQDN Server.contoso.com -ArcRemoteShare AzureArcOnBoard -ServicePrincipalSecret $ServicePrincipalSecret 
-       -ServicePrincipalClientId $ServicePrincipalClientId -SubscriptionId $SubscriptionId --ResourceGroup $ResourceGroup -Location $Location -TenantId $TenantId 
+       -ServicePrincipalClientId $ServicePrincipalClientId -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -Location $Location -TenantId $TenantId 
        [-AgentProxy $AgentProxy]
 
 #>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ More information can be found [here](https://learn.microsoft.com/en-us/azure/azu
 - Execute the deployment script *DeployGPO.ps1*, with the following syntax:
   
         .\DeployGPO.ps1 -DomainFQDN contoso.com -ReportServerFQDN Server.contoso.com -ArcRemoteShare AzureArcOnBoard -ServicePrincipalSecret $ServicePrincipalSecret 
-       -ServicePrincipalClientId $ServicePrincipalClientId -SubscriptionId $SubscriptionId --ResourceGroup $ResourceGroup -Location $Location -TenantId $TenantId 
+       -ServicePrincipalClientId $ServicePrincipalClientId -SubscriptionId $SubscriptionId -ResourceGroup $ResourceGroup -Location $Location -TenantId $TenantId 
        [-AgentProxy $AgentProxy]
 
     Where:


### PR DESCRIPTION
We got some trouble and find out documentation and header comment had --ResourceGroup typo