### PR TITLE
Increase IMDS timeout from 3 to 10 seconds to prevent false negatives

### DIFF
--- a/EnableAzureArc.ps1
+++ b/EnableAzureArc.ps1
@@ -496,7 +496,7 @@ else {
 try {
     $TestAzuremachine = Invoke-RestMethod -Headers @{"Metadata" = "true" } `
         -Method GET -Proxy $Null -Uri "http://169.254.169.254/metadata/instance?api-version=2020-09-01"`
-        -TimeoutSec 3 -ErrorAction SilentlyContinue | ConvertTo-Json -Depth 64
+        -TimeoutSec 10 -ErrorAction SilentlyContinue | ConvertTo-Json -Depth 64
 }
 catch {}
 If ($Null -ne $TestAzuremachine) {


### PR DESCRIPTION
## Problem

The IMDS check in `EnableAzureArc.ps1` uses a 3-second timeout (`-TimeoutSec 3`) to determine if a machine is an Azure VM. If IMDS does not respond within 3 seconds — for example due to transient host-level activity — the empty `catch {}` block silently handles the timeout, `\` stays `\`, and the script proceeds to onboard the machine to Azure Arc as if it were a non-Azure machine.

## Real-world impact

This was observed in production where a domain controller running as an Azure VM was accidentally onboarded to Azure Arc. The onboarding log showed hundreds of successful IMDS checks (responding in under 1 second), but on a single run the check took exactly 3 seconds (the timeout limit), causing the script to misidentify the Azure VM and install the Connected Machine agent.

## Fix

Increase `-TimeoutSec` from `3` to `10`. This provides a much safer margin for transient IMDS slowness while having no practical impact on non-Azure machines, where the IMDS endpoint is unreachable and the connection will fail/timeout regardless.